### PR TITLE
fix: reliably quit on ESC key press in start/game over screens

### DIFF
--- a/Shmup.py
+++ b/Shmup.py
@@ -69,16 +69,27 @@ def show_start_screen():
     waiting = True
     while waiting:
         clock.tick(FPS)
-        keystate = pg.key.get_pressed()
+        # keystate = pg.key.get_pressed()
         for event in pg.event.get():
             if event.type == pg.QUIT:
                 pg.quit()
                 exit()
-            if keystate[pg.K_ESCAPE]:
-                pg.quit()
-                exit()
-            if event.type == pg.KEYUP:
-                waiting = False
+             # --- NEW LOGIC STARTS HERE ---
+            if event.type == pg.KEYDOWN:
+                # A key was PRESSED. Now let's see which one.
+                if event.key == pg.K_ESCAPE:
+                    # Specifically, the ESC key was pressed. Quit.
+                    pg.quit()
+                    exit()                    
+                else:
+                # Any other key (Space, Enter, etc.) was pressed. Start the game.
+                    waiting = False
+            # --- NEW LOGIC ENDS HERE ---
+            # if keystate[pg.K_ESCAPE]:
+            #     pg.quit()
+            #     exit()
+            # if event.type == pg.KEYUP:
+            #     waiting = False
 
 
 def show_go_screen():
@@ -98,16 +109,27 @@ def show_go_screen():
     waiting = True
     while waiting:
         clock.tick(FPS)
-        keystate = pg.key.get_pressed()
+        # keystate = pg.key.get_pressed()
         for event in pg.event.get():
             if event.type == pg.QUIT:
                 pg.quit()
                 exit()
-            if keystate[pg.K_ESCAPE]:
-                pg.quit()
-                exit()
-            if event.type == pg.KEYUP:
-                waiting = False
+            # --- NEW LOGIC STARTS HERE ---
+            if event.type == pg.KEYDOWN:
+                # A key was PRESSED. Now let's see which one.
+                if event.key == pg.K_ESCAPE:
+                    # Specifically, the ESC key was pressed. Quit.
+                    pg.quit()
+                    exit()                    
+                else:
+                # Any other key (Space, Enter, etc.) was pressed. Start the game.
+                    waiting = False
+            # --- NEW LOGIC ENDS HERE ---
+            # if keystate[pg.K_ESCAPE]:
+            #     pg.quit()
+            #     exit()
+            # if event.type == pg.KEYUP:
+            #     waiting = False
 
 
 class Player(pg.sprite.Sprite):


### PR DESCRIPTION
**## What this PR does**

- Replaces the key state check (`pg.key.get_pressed()`) for the ESC key with a key event check (`event.type == pg.KEYDOWN`) in the `show_start_screen()` and `show_go_screen()` functions.
    

**## Why this change is needed**

- **The old method was unreliable.** It checked if the ESC key was _held down_ during any event processing, which could lead to inconsistent behavior (e.g., the game sometimes starting instead of quitting if the key was released quickly).
    
- **The new method is precise.** It only triggers on the actual press of the ESC key, making the quit action immediate and consistent.
    
- **Improves user experience.** The game now also starts on the _press_ of any key, not the _release_, making it feel more responsive.
    

**## Testing Performed**

- Tested that pressing ESC on the start and game over screens now consistently quits the game.
    
- Tested that pressing any other key (e.g., SPACE, ENTER) consistently starts the game.
    
- Verified that pressing ESC during gameplay continues to do nothing (as intended).