### PR TITLE
refactor: rename function for clarity

### DIFF
--- a/Shmup.py
+++ b/Shmup.py
@@ -92,7 +92,7 @@ def show_start_screen():
             #     waiting = False
 
 
-def show_go_screen():
+def show_game_over_screen():
     screen.blit(background, background_rect)
     draw_text(screen, "GAME OVER", 48, WIDTH / 2, HEIGHT / 4)
     draw_text(screen, "Score: " + str(score), 22, WIDTH / 2, HEIGHT / 2)
@@ -496,7 +496,7 @@ while running:
 
     if game_over:
 
-        show_go_screen()
+        show_game_over_screen()
         game_over = False
         all_sprites = pg.sprite.Group()
         mobs = pg.sprite.Group()


### PR DESCRIPTION
- Renamed `show_go_screen()` to `show_game_over_screen()`.
- The abbreviation 'go' was ambiguous and could be misinterpreted (e.g., as 'game object' or the verb 'to go').
- The new name is self-documenting and instantly communicates the function's purpose, improving code readability and maintainability.
- This change was applied using VS Code's rename symbol refactor tool to ensure all references were updated.