### PR TITLE
refactor: implement generic show_waiting_screen function

### DIFF
--- a/Shmup.py
+++ b/Shmup.py
@@ -73,41 +73,67 @@ def should_continue_waiting():
             else:
                 # Any other key (Space, Enter, etc.) was pressed. Start the game.
                 return False
-    return True
+    return True    
 
-def show_start_screen():
-    screen.blit(background, background_rect)
+def show_waiting_screen(*draw_callbacks):
+    """
+    A generic screen that waits for user input.
+    
+    Parameters:
+        *draw_callbacks: One or more functions to call each frame to draw the screen.
+                         These are "callbacks" - we pass them in to be called later.
+    """
+    waiting = True
+    while waiting:
+        waiting = should_continue_waiting()
+
+        screen.blit(background, background_rect)
+
+        for draw_callback in draw_callbacks:
+            draw_callback()
+
+        pg.display.flip()
+        clock.tick(FPS)
+
+def draw_start_title():
+    """Callback function to draw the title for the start screen."""
     draw_text(screen, "SHMUP!", 64, WIDTH / 2, HEIGHT / 4)
     draw_text(screen, "Arrow keys move, Space to fire", 22, WIDTH / 2, HEIGHT / 2)
     draw_text(screen, "Press a key to begin", 18, WIDTH / 2, HEIGHT * 3 / 4)
-    draw_text(screen, "High Score: " + str(player.highscore), 22, WIDTH / 2, 15)    
-    waiting = True
-    while waiting:                
-        waiting = should_continue_waiting()
-        pg.display.flip()
-        clock.tick(FPS)     
-    return
 
-      
-def show_game_over_screen():
-    screen.blit(background, background_rect)
+def draw_start_highscore():
+    """Callback function to draw the high score for the start screen."""
+    draw_text(screen, "High Score: " + str(player.highscore), 22, WIDTH / 2, 15)
+
+def draw_game_over_title():
+    """Callback function to draw the title for the game over screen."""
     draw_text(screen, "GAME OVER", 48, WIDTH / 2, HEIGHT / 4)
     draw_text(screen, "Score: " + str(score), 22, WIDTH / 2, HEIGHT / 2)
     draw_text(screen, "Press a key to play again", 18, WIDTH / 2, HEIGHT * 3 / 4)
+
+def show_start_screen():
+    """Shows the start screen by using the generic waiting screen with specific draw functions."""
+    show_waiting_screen(draw_start_title, draw_start_highscore)
+
+
+def show_game_over_screen():
+    """Shows the game over screen by using the generic waiting screen with specific draw functions."""
+    new_high_score_achieved = False
     if score > player.highscore:
         player.highscore = score
-        draw_text(screen, "NEW HIGH SCORE!", 22, WIDTH / 2, HEIGHT / 2 + 40)
+        new_high_score_achieved = True
         with open(path.join(player.dir, HS_FILE), "w") as f:
             f.write(str(score))
-    else:
-        draw_text(screen, "High Score: " + str(player.highscore), 22, WIDTH / 2, HEIGHT / 2 + 40)
 
-    waiting = True
-    while waiting:        
-        waiting = should_continue_waiting()
-        pg.display.flip()
-        clock.tick(FPS)
-    return
+    def draw_game_over_highscore():
+        """Callback function to draw the high score for the game over screen."""
+        if new_high_score_achieved:
+            draw_text(screen, "NEW HIGH SCORE!", 22, WIDTH / 2, HEIGHT / 2 + 40)        
+        else:
+            draw_text(screen, "High Score: " + str(player.highscore), 22, WIDTH / 2, HEIGHT / 2 + 40)
+
+
+    show_waiting_screen(draw_game_over_title, draw_game_over_highscore)
 
 
 class Player(pg.sprite.Sprite):


### PR DESCRIPTION
- Created a generic show_waiting_screen(*draw_callbacks) function to handle the common waiting loop logic, eliminating duplication in screen functions.
- Refactored show_start_screen() and show_game_over_screen() to use the new generic function by passing specific drawing callbacks.
- Utilized a closure in show_game_over_screen() to handle the one-time high score check and persistent drawing state correctly.
- This new structure provides a clean pattern for future screens (e.g., a pause menu).

Closes #11