### PR TITLE
fix: resolve input priority conflict for left/right movement

### DIFF
--- a/Shmup.py
+++ b/Shmup.py
@@ -195,10 +195,12 @@ class Player(pg.sprite.Sprite):
 
         self.speedx = 0
         keystate = pg.key.get_pressed()
-        if keystate[pg.K_LEFT]:
+        if keystate[pg.K_LEFT] and not keystate[pg.K_RIGHT]:
             self.speedx = -8
-        if keystate[pg.K_RIGHT]:
+        elif keystate[pg.K_RIGHT] and not keystate[pg.K_LEFT]:
             self.speedx = 8
+        else:
+            self.speedx = 0
         if keystate[pg.K_SPACE]:
             self.shoot()
         self.rect.x += self.speedx


### PR DESCRIPTION
The movement logic used independent `if` statements for left and right input checks. This caused the right movement to consistently overwrite the left movement when both keys were pressed, as it was the last statement evaluated.

Refactored to use an `if-elif-else` chain with explicit condition checks to handle the four possible input states correctly:
- Left only: move left
- Right only: move right
- Both or neither: stop

This ensures the intended behavior where simultaneous key presses result in no movement, resolving the control ambiguity.

Closes #8