### PR TITLE
fix: Correct PyInstaller command to use Shmup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ This game can be packaged into a standalone application using [PyInstaller](http
     **Option 1: Create a Distribution Folder (Recommended for testing)**
     *Easier to debug if necessary, as all files are in one folder.*
     ```bash
-    pyinstaller --onedir --windowed --add-data "img;img" --add-data "snd;snd" --add-data "licenses;licenses" --add-data "CREDITS.txt;." --icon=game_icon.ico main.py
+    pyinstaller --onedir --windowed --add-data "img;img" --add-data "snd;snd" --add-data "licenses;licenses" --add-data "CREDITS.txt;." --icon=game_icon.ico Shmup.py
     ```
     *The executable (`Shmup.exe`) and all required game files will be created in the `dist/Shmup/` directory. You can distribute the entire `dist/Shmup` folder.*
 
     **Option 2: Create a Single Executable File**
     *Creates a single, portable `.exe` file for distribution.*
     ```bash
-    pyinstaller --onefile --windowed --add-data "img;img" --add-data "snd;snd" --add-data "licenses;licenses" --add-data "CREDITS.txt;." --icon=game_icon.ico main.py
+    pyinstaller --onefile --windowed --add-data "img;img" --add-data "snd;snd" --add-data "licenses;licenses" --add-data "CREDITS.txt;." --icon=game_icon.ico Shmup.py
     ```
     *A single executable file (`Shmup.exe`) will be created in the `dist/` directory.*
 


### PR DESCRIPTION
- Update all PyInstaller commands in README from 'main.py' to 'Shmup.py'
- Ensure build instructions match actual project structure
- Maintain all existing data file inclusions and flags